### PR TITLE
bug: check web in deepExtract

### DIFF
--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -83,11 +83,13 @@ Function deepExtract(params, web)
     deepExtract = -1
 
     If Not objfs.FolderExists(cachePath) Then
-        deepExtract = objws.Run(""""& params(IP_InstallFile) &""" /quiet /layout """& cachePath &"""", 0, True)
-        If deepExtract Then
-            WScript.Echo ":: [Error] :: error extracting the web portion from the installer."
-            Exit Function
-        End If
+	If web Then
+        	deepExtract = objws.Run(""""& params(IP_InstallFile) &""" /quiet /layout """& cachePath &"""", 0, True)
+        	If deepExtract Then
+            		WScript.Echo ":: [Error] :: error extracting the web portion from the installer."
+            		Exit Function
+        	End If
+	End If
         If Not web Then
             deepExtract = objws.Run(""""& strDirWiX &"\dark.exe"" -x """& cachePath &""" """& params(IP_InstallFile) &"""", 0, True)
             If deepExtract Then


### PR DESCRIPTION
Not checking if web in deepExtract results in an error when installing recent versions of Python.